### PR TITLE
fix init.sh: syntax change

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$PYTHON" == "" ]; then
+if [ "$PYTHON" = "" ]; then
     PYTHON="python"
 fi
 
@@ -15,7 +15,7 @@ fi
 
 . venv/bin/activate
 
-if [ $(uname -s) == "Darwin" ]; then
+if [ $(uname -s) = "Darwin" ]; then
     # Mac OS X Mountain Lion compiles with clang by default...
     # clang and cython don't get along... so force it to use gcc
 


### PR DESCRIPTION
was getting errors when running make. 

``` bash
./init.sh: 3: [: unexpected operator
./init.sh: 18: [: Linux: unexpected operator
./init.sh: 32: [: Illegal number: sh:
./init.sh: 36: [: Illegal number: 30:
./init.sh: 40: [: Illegal number: 30:
```

Proposed fix:- 

syntax changed from `==` to `=` to fix  
eg:  

``` bash
if [ "$PYTHON" = "" ]; then
    PYTHON="python"
fi
```
